### PR TITLE
Fix Lerna change detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function checkChangelog() {
   const gitChangedFiles = (await execAndReturnOutput(`git --no-pager diff origin/${baseRef} --name-only`)).trim().split("\n");
 
   if(lerna) {
-    const lernaPackages = JSON.parse(await execAndReturnOutput(`npx lerna changed --json --loglevel silent`));
+    const lernaPackages = JSON.parse(await execAndReturnOutput(`npx lerna list --since origin/${baseRef} --exclude-dependents --json --loglevel silent`));
     var errors = "";
     for (const package of lernaPackages) {
       const changelogLocation = path.join(path.relative(directory, package.location), file);


### PR DESCRIPTION
This fixes the changelog check on https://github.com/zowe/zowe-cli/pull/836

We only care about changes that happened in a branch/PR, not everything that changed since the last Git tag.

The updated Lerna command matches the one used in our Jenkins shared library:
https://github.com/zowe/zowe-cli-version-controller/blob/5b67cb0d082a0c2196b97839eb1fc09d0eb84a37/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy#L1213