### PR TITLE
Add support for Yarn workspaces 🧶 🧶 🧶 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Whether or not this is a lerna monorepo'
     required: false
     default: false
+  yarnWorkspaces:
+    description: 'Whether or not this is a yarn workspaces monorepo'
+    required: false
+    default: false
   ignoreFiles:
     description: 'The files in a repository that, if changed, do not require a changelog update'
     required: false

--- a/index.js
+++ b/index.js
@@ -135,9 +135,9 @@ async function checkChangelog() {
       }
     }
 
-    changes = changes ?? false;
-    changed = changed ?? false;
-    headerFound = headerFound ?? false;
+    changes = changes || false;
+    changed = changed || false;
+    headerFound = headerFound || false;
 
     if (changes == true) {
       if (changed == false) {

--- a/index.js
+++ b/index.js
@@ -4,16 +4,22 @@ const execa = require('execa');
 const fs = require('fs');
 const path = require('path');
 
-const directory = process.env.GITHUB_WORKSPACE
-const eventPath = process.env.GITHUB_EVENT_PATH
+const directory = process.env.GITHUB_WORKSPACE;
+const eventPath = process.env.GITHUB_EVENT_PATH;
 const header = core.getInput('header');
 const file = core.getInput('file');
 const ignoreFiles = core.getInput('ignoreFiles');
 const lerna = (core.getInput('lerna').toLowerCase() === "true");
+const yarnWorkspaces = (core.getInput('yarnWorkspaces').toLowerCase() === "true");
 
-var changes = undefined;
-var changed = undefined;
-var headerFound = undefined;
+const REPORT_ISSUE = `
+Please provide a link with the failing build to:
+https://github.com/awharn/check_changelog_action/issues/new
+`;
+
+let changes;
+let changed;
+let headerFound;
 
 async function execAndReturnOutput(command) {
   let capturedOutput = "";
@@ -44,110 +50,119 @@ async function checkChangelog() {
   const eventData = JSON.parse(fs.readFileSync(eventPath, "utf-8"));
   const baseRef = eventData.pull_request.base.ref;
   const gitChangedFiles = (await execAndReturnOutput(`git --no-pager diff origin/${baseRef} --name-only`)).trim().split("\n");
+  let errors = "";
 
-  if(lerna) {
-    let lernaPackages = JSON.parse(await execAndReturnOutput(`npx lerna list --since origin/${baseRef} --exclude-dependents --json --loglevel silent`));
-    var errors = "";
-    for (const package of lernaPackages) {
+  if (lerna || yarnWorkspaces) {
+    let packages = [];
+    if (yarnWorkspaces) {
+      const yarnVersion = (await execAndReturnOutput("npx yarn --version")).trim();
+      if (yarnVersion.startsWith("1.")) {
+        const workspaceInfo = JSON.parse((await execAndReturnOutput("npx yarn workspaces info --json --silent")).trim().split("\n").slice(1, -1).join(""));
+        for (const p in workspaceInfo) {
+          packages.push({
+            name: p,
+            location: workspaceInfo[p].location
+          });
+        }
+      } else if (yarnVersion.startsWith("2.")) {
+        // TODO: test yarn 2.x support
+        packages = JSON.parse((await execAndReturnOutput("npx yarn workspaces info --json")).trim());
+      } else {
+        changes = false;
+        changed = false;
+        headerFound = false;
+        core.error(`Only Yarn 1.x and 2.x are supported. ${REPORT_ISSUE}`);
+      }
+    } else if (lerna) {
+      packages = JSON.parse(await execAndReturnOutput(`npx lerna list --since origin/${baseRef} --exclude-dependents --json --loglevel silent`));
+    }
+
+    for (const package of packages) {
       const resolvedPkgDir = path.join(path.relative(directory, package.location));
       let modifiedFiles = await execAndReturnOutputExeca(`git diff --name-only origin/${baseRef}..HEAD -- ${resolvedPkgDir} | grep -Ev '${ignoreFiles}' || true`);
       if (modifiedFiles.length == 0) {
-        lernaPackages = lernaPackages.filter(packages => packages.name != package.name);
+        packages = packages.filter(packages => packages.name != package.name);
       }
     }
 
-    if (lernaPackages.length == 0) {
+    if (packages.length == 0) {
       changes = false;
       changed = false;
       headerFound = false;
     } else {
       changes = true;
-      for (const package of lernaPackages) {
+      for (const package of packages) {
         const changelogLocation = path.join(path.relative(directory, package.location), file);
         let changedLocal = false;
         let headerFoundLocal = false;
         for (const filename of gitChangedFiles) {
           if (filename == changelogLocation) {
             changedLocal = true;
-            var contents = fs.readFileSync(directory + "/" + filename);
+            let contents = fs.readFileSync(directory + "/" + filename);
             headerFoundLocal = contents.includes(header);
             break;
           }
         }
 
-        if (changedLocal == true) {
-          if (changed == null || changed == true) {
+        if (changedLocal === true) {
+          if (changed == null) {
             changed = true;
           }
 
-          if (headerFoundLocal == true && headerFound != false) {
+          if (headerFoundLocal === true && headerFound == null) {
             headerFound = true;
-          } else if (headerFoundLocal == false) {
+          } else if (headerFoundLocal === false) {
             headerFound = false;
             errors = errors + `The changelog has changed in ${changelogLocation}, but the required header is missing.\n`;
           }
-        } else if (changedLocal == false) {
+        } else if (changedLocal === false) {
           changed = false;
           headerFound = false;
           errors = errors + `The changelog was not changed in this pull request for ${changelogLocation}.\n`;
         }
       }
     }
-
-    if (changes == undefined) { console.log("Changes is undefined. Please report this issue."); }
-    if (changed == undefined) { console.log("Changed is undefined. Please report this issue."); }
-    if (header == undefined) { console.log("Header is undefined. Please report this issue."); }
-
-    core.setOutput('changes', changes.toString());
-    core.setOutput('changed', changed.toString());
-    core.setOutput('header', headerFound.toString());
-
-    if (changes == true && (changed == false || headerFound == false)) {
-      const err = new Error(errors);
-      err.stack = "";
-      throw err;
-    }
-
   } else {
     let modifiedFiles = await execAndReturnOutputExeca(`git diff --name-only origin/${baseRef}..HEAD -- $(pwd) | grep -Ev '${ignoreFiles}' || true`);
-    if (modifiedFiles.length == 0) {
-      changes = false;
-      changed = false;
-      headerFound = false;
-    } else {
+    if (modifiedFiles.length > 0) {
       changes = true;
       for (const filename of gitChangedFiles) {
         if (filename.includes(file)) {
           changed = true;
-          var contents = fs.readFileSync(directory + "/" + filename);
+          let contents = fs.readFileSync(path.join(directory, filename));
           headerFound = contents.includes(header);
         }
       }
     }
-    
-    changed = changed || false;
-    headerFound = headerFound || false;
 
-    if (changes == undefined) { console.log("Changes is undefined. Please report this issue."); }
-    if (changed == undefined) { console.log("Changed is undefined. Please report this issue."); }
-    if (headerFound == undefined) { console.log("Header is undefined. Please report this issue."); }
-
-    core.setOutput('changes', changes.toString());
-    core.setOutput('changed', changed.toString());
-    core.setOutput('header', headerFound.toString());
+    changes = changes ?? false;
+    changed = changed ?? false;
+    headerFound = headerFound ?? false;
 
     if (changes == true) {
       if (changed == false) {
-        const err = new Error("The changelog was not changed in this pull request.");
-        err.stack = "";
-        throw err;
-      } else if (headerFound == false) {
-        const err = new Error("The changelog has changed, but the required header is missing.");
-        err.stack = "";
-        throw err;
+        errors = errors + "The changelog was not changed in this pull request.";
+      }
+      if (headerFound == false) {
+        errors = errors + "The changelog has changed, but the required header is missing.";
       }
     }
   }
+
+  // Handle issues with this action
+  if (changes === undefined) core.error(`Changes is undefined. ${REPORT_ISSUE}`);
+  if (changed === undefined) core.error(`Changed is undefined. ${REPORT_ISSUE}`);
+  if (headerFound === undefined) core.error(`HeaderFound is undefined. ${REPORT_ISSUE}`);
+
+  if (changes === true && (changed === false || headerFound === false)) {
+    const err = new Error(errors);
+    err.stack = "";
+    throw err;
+  }
+
+  core.setOutput('changes', changes.toString());
+  core.setOutput('changed', changed.toString());
+  core.setOutput('header', headerFound.toString());
 }
 
 checkChangelog().catch((error) => {


### PR DESCRIPTION
Tested via this sample PR https://github.com/zFernand0/vscode-extension-for-zowe/pull/1/commits/df19e75ae37ec31c3b3adc9e71e7c7bc30208e00
Here are the results: https://github.com/zFernand0/vscode-extension-for-zowe/actions/runs/3200316454

**No error message ???**
- No changelog in a package within the monorepo

**Expected errors**
- Missing changelog updates for zowe-explorer-api
- Expected label is present (zowe-explorer), but the changelog was not updated in this PR
- Default label (Recent Changes) found but expected header (based on configuration) not found

**Summary**
```
changelog
The changelog was not changed in this pull request for packages/zowe-explorer-api/CHANGELOG.md.
The changelog has changed in packages/zowe-explorer-ftp-extension/CHANGELOG.md, but the required header is missing.
The changelog was not changed in this pull request for packages/zowe-explorer/CHANGELOG.md.
```

Needs more 🧶 testing