### PR TITLE
Add temporary `lerna` support

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ async function checkChangelog() {
     } else if (lerna) {
       let isLernaTemp = false;
       if (!fs.existsSync("lerna.json")) {
+        const packageJson = JSON.parse(fs.readFileSync("package.json", "utf-8"));
         isLernaTemp = true;
         fs.writeFileSync("lerna.json", JSON.stringify({
             version: packageJson.version,

--- a/index.js
+++ b/index.js
@@ -83,7 +83,18 @@ async function checkChangelog() {
         core.error(`Only Yarn 1.x and 2.x are supported. ${REPORT_ISSUE}`);
       }
     } else if (lerna) {
+      let isLernaTemp = false;
+      if (!fs.existsSync("lerna.json")) {
+        isLernaTemp = true;
+        fs.writeFileSync("lerna.json", JSON.stringify({
+            version: packageJson.version,
+            useWorkspaces: true
+        }, null, 2));
+      }
       packages = JSON.parse(await execAndReturnOutput(`${npxCmd} lerna@6 list --since origin/${baseRef} --exclude-dependents --json --loglevel silent`));
+      if (isLernaTemp) {
+        fs.rmSync("lerna.json", {force: true});
+      }
     }
 
     for (const package of packages) {


### PR DESCRIPTION
This PR follows the same idea behind: 
- https://github.com/zowe-actions/octorelease/pull/129

In theory, the `lerna.json` is not required if all that's needed is the `useWorkspaces: true` and possibly the `version` properties.

Here is a working example:
- https://github.com/zowe/cics-for-zowe-client/actions/runs/7785188075/job/21227181408?pr=28